### PR TITLE
Integrate with scala-cli install-home command

### DIFF
--- a/scala-setup.sh
+++ b/scala-setup.sh
@@ -37,10 +37,10 @@ rm ${SCALA_CLI_BIN_FILE}
 
 case "$UNAME" in
     Linux)
-        echo "'~/.profile' has been updated"
-        echo "To make scala-cli visible, you have to start a new login shell"
+        echo "Profile file(s) updated."
+        echo "To run scala-cli, log out and log back in, or run 'source ~/.profile'"
         ;;
     Darwin)
-        echo "If scala-cli is not visible, just open new terminal"
+        echo "To run scala-cli, open new terminal or run 'source ~/.profile'"
         ;;
 esac

--- a/scala-setup.sh
+++ b/scala-setup.sh
@@ -32,4 +32,9 @@ SCALA_CLI_BIN_FILE="${TMP_DIR}/scala-cli"
 curl -fLo ${SCALA_CLI_ARCHIVE} $URL
 gzip -d ${SCALA_CLI_ARCHIVE}
 chmod +x ${SCALA_CLI_BIN_FILE}
-mv ${SCALA_CLI_BIN_FILE} /usr/local/bin/scala-cli
+"./${SCALA_CLI_BIN_FILE}" install-home --scala-cli-binary-path ${SCALA_CLI_BIN_FILE}
+rm ${SCALA_CLI_BIN_FILE}
+
+echo "scala-cli installed"
+echo "'~/.profile' has been updated"
+echo "To make scala-cli visible, you have to start a new login shell"

--- a/scala-setup.sh
+++ b/scala-setup.sh
@@ -3,10 +3,10 @@ set -eu
 
 SCALA_CLI_BASE_URL="https://github.com/Virtuslab/scala-cli/releases/latest/download/"
 
+UNAME="$(uname)"
+
 architecture() {
-    
-    UNAME="$(uname)"
-    
+
     case "$UNAME" in
         Linux)
             OS_NAME=pc-linux
@@ -32,9 +32,15 @@ SCALA_CLI_BIN_FILE="${TMP_DIR}/scala-cli"
 curl -fLo ${SCALA_CLI_ARCHIVE} $URL
 gzip -d ${SCALA_CLI_ARCHIVE}
 chmod +x ${SCALA_CLI_BIN_FILE}
-"./${SCALA_CLI_BIN_FILE}" install-home --scala-cli-binary-path ${SCALA_CLI_BIN_FILE}
+"${SCALA_CLI_BIN_FILE}" install-home --scala-cli-binary-path ${SCALA_CLI_BIN_FILE}
 rm ${SCALA_CLI_BIN_FILE}
 
-echo "scala-cli installed"
-echo "'~/.profile' has been updated"
-echo "To make scala-cli visible, you have to start a new login shell"
+case "$UNAME" in
+    Linux)
+        echo "'~/.profile' has been updated"
+        echo "To make scala-cli visible, you have to start a new login shell"
+        ;;
+    Darwin)
+        echo "If scala-cli is not visible, just open new terminal"
+        ;;
+esac


### PR DESCRIPTION
We want to make more interactive installation script with user. 
It was prepared [install-home](https://github.com/VirtusLab/scala-cli/blob/master/modules/cli/src/main/scala/scala/cli/commands/InstallHome.scala) command in scala-cli to add binary of scala-cli to PATH in ~/.profile