### PR TITLE
Run hello world in test

### DIFF
--- a/.github/scripts/test.sh
+++ b/.github/scripts/test.sh
@@ -2,10 +2,10 @@
 set -eu
 
 docker build -t scala-cli-alpine -f .github/scripts/docker/AlpineDockerFile . 
-docker run scala-cli-alpine about
+docker run scala-cli-alpine -e 'println("Hello World")'
 
 docker build -t scala-cli-ubuntu -f .github/scripts/docker/DebianDockerFile .
-docker run scala-cli-ubuntu about
+docker run scala-cli-ubuntu -e 'println("Hello World")'
 
 docker build -t scala-cli-fedora -f .github/scripts/docker/CentOSDockerFile .
-docker run scala-cli-fedora about
+docker run scala-cli-fedora -e 'println("Hello World")'


### PR DESCRIPTION
Since `about` command was removed from `scala-cli` https://github.com/VirtusLab/scala-cli/pull/1744, the tests in `scala-cli-packages` fails. So I update it and run `hello world` test instead of running `about` command. 