### PR TITLE
Use `=` comparator to avoid unexpected operator error

### DIFF
--- a/scala-setup.sh
+++ b/scala-setup.sh
@@ -21,7 +21,7 @@ architecture() {
     case "$UNAME" in
         Linux)
             OS_NAME=pc-linux
-            if [ "$(uname -m)" == "aarch64" ]; then
+            if [ "$(uname -m)" = "aarch64" ]; then
               OS_ARCH="aarch64"
             fi
             ;;


### PR DESCRIPTION
Fixes the following error on linux:

```
curl -sSLf https://virtuslab.github.io/scala-cli-packages/scala-setup.sh | sh
sh: 24: [: x86_64: unexpected operator
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
```