### PR TITLE
Update debian install instruction - apt key is deprecated

### DIFF
--- a/.github/scripts/docker/DebianDockerFile
+++ b/.github/scripts/docker/DebianDockerFile
@@ -2,7 +2,7 @@ FROM debian:latest
 USER root
 RUN apt update
 RUN apt install curl gnupg -y
-RUN curl -fsSL "https://virtuslab.github.io/scala-cli-packages/KEY.gpg"  | apt-key add -
+RUN curl -sS "https://virtuslab.github.io/scala-cli-packages/KEY.gpg" | gpg --dearmor  -o /etc/apt/trusted.gpg.d/scala-cli.gpg 2>/dev/null
 RUN curl -s --compressed -o /etc/apt/sources.list.d/scala_cli_packages.list "https://virtuslab.github.io/scala-cli-packages/debian/scala_cli_packages.list"
 RUN apt update
 RUN apt install scala-cli -y

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repo is automatically updated in react to the Scala CLI release.
 ### How to install
 
 ```
-curl -s --compressed "https://virtuslab.github.io/scala-cli-packages/KEY.gpg" | sudo apt-key add -
+curl -sS "https://virtuslab.github.io/scala-cli-packages/KEY.gpg" | sudo gpg --dearmor  -o /etc/apt/trusted.gpg.d/scala-cli.gpg 2>/dev/null
 sudo curl -s --compressed -o /etc/apt/sources.list.d/scala_cli_packages.list "https://virtuslab.github.io/scala-cli-packages/debian/scala_cli_packages.list"
 sudo apt update
 sudo apt install scala-cli


### PR DESCRIPTION
Fixes #17. @DavidGoodenough Thanks for suggestion!

Debian installation was updated to eliminate the use of the deprecated `apt-key`.